### PR TITLE
Fixes #10: Correct focus detection for type-to-search (WinUI 3)

### DIFF
--- a/PolicyPlusPlus/MainWindow/MissingHandlers.cs
+++ b/PolicyPlusPlus/MainWindow/MissingHandlers.cs
@@ -286,7 +286,6 @@ namespace PolicyPlusPlus
                         }
                         catch (Exception ex)
                         {
-                            // Use debug instead because this is not a fatal error.
                             Logging.Log.Debug(
                                 "MainWindow",
                                 "GetFocusedElement failed: " + ex.Message
@@ -296,7 +295,6 @@ namespace PolicyPlusPlus
                         {
                             // Fallback to event source if FocusManager did not return a focused element.
                             focused = e.OriginalSource as DependencyObject;
-                            // Use debug instead because this is not a fatal error.
                             Logging.Log.Debug(
                                 "MainWindow",
                                 "Focused element null; using OriginalSource fallback"
@@ -315,7 +313,6 @@ namespace PolicyPlusPlus
                             }
                             catch (Exception ex)
                             {
-                                // Use warn because this is unexpected.
                                 Logging.Log.Warn("MainWindow", "SearchBox.Focus failed", ex);
                             }
                             try
@@ -329,7 +326,6 @@ namespace PolicyPlusPlus
                                 }
                                 else
                                 {
-                                    // Use debug instead because this is not a fatal error.
                                     Logging.Log.Debug(
                                         "MainWindow",
                                         "inner TextBox not found in SearchBox"
@@ -338,7 +334,6 @@ namespace PolicyPlusPlus
                             }
                             catch (Exception ex)
                             {
-                                // Use debug instead because this is not a fatal error.
                                 Logging.Log.Debug(
                                     "MainWindow",
                                     "SearchBox caret move failed: " + ex.Message


### PR DESCRIPTION
This PR is aiming to resolve an issue discussed in https://github.com/tttza/PolicyPlusPlus/issues/10

---

This pull request improves the robustness and debuggability of keyboard focus handling in the `RootGrid_KeyDown` event handler. The main changes involve safer retrieval of the focused UI element, enhanced error logging, and better fallback logic to prevent crashes and aid diagnostics.

**Focus handling improvements:**

* Updated the logic for retrieving the focused element to use `XamlRoot`-aware methods, with fallback to the event source if focus retrieval fails. This addresses cases where `FocusManager.GetFocusedElement()` may return null in WinUI 3 desktop scenarios.
* Added debug-level logging for failures in focus retrieval and when falling back to the event source, improving traceability of focus issues.

**Error handling and diagnostics:**

* Changed generic catch blocks to catch `Exception` explicitly and log warnings when `SearchBox.Focus` fails, making unexpected errors more visible.
* Added debug-level logging for cases when the inner `TextBox` in `SearchBox` cannot be found, and when moving the caret fails due to exceptions, aiding troubleshooting of UI focus and selection issues.
