### PR TITLE
Feature/issue 4 gpo refresh warnings update

### DIFF
--- a/PolicyPPElevationHost/ElevationHost.cs
+++ b/PolicyPPElevationHost/ElevationHost.cs
@@ -455,7 +455,7 @@ namespace PolicyPPElevationHost
                     return null;
                 }
 
-                // Skip DC reachability checks when the machine is not domain-joined (workgroup/AAD join).
+                // Skip DC reachability checks when the machine is not domain-joined (workgroup/AAD joined).
                 if (status != NetSetupJoinStatus.NetSetupDomainName)
                     return null;
 


### PR DESCRIPTION
This pull request makes a minor cleanup to the `ElevationHost.cs` file by removing an unused struct and correcting a comment.

- Code cleanup:
  * Removed the unused `DomainControllerInfo` struct from `ElevationHost.cs` to simplify the codebase.

- Documentation improvement:
  * Updated a comment in the `Run` method to clarify that DC reachability checks are skipped when the machine is workgroup or Azure AD (AAD) joined.