### PR TITLE
Policy List UI improvements.

### DIFF
--- a/PolicyPlusPlus/MainWindow.xaml
+++ b/PolicyPlusPlus/MainWindow.xaml
@@ -868,6 +868,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding DisplayName, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -900,6 +901,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding SecondName, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -926,6 +928,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding ShortId, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -956,6 +959,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding CategoryName, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -987,6 +991,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding TopCategoryName, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -1018,6 +1023,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding CategoryFullPath, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -1048,6 +1054,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding AppliesText, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>
@@ -1078,6 +1085,7 @@
                           TextTrimming="CharacterEllipsis"
                           TextWrapping="NoWrap"
                           Margin="8,0,8,0"
+                          Loaded="CellTextBlock_Loaded"
                           AutomationProperties.Name="{Binding SupportedText, Converter={StaticResource NullOrWhitespaceToFallbackConverter}, ConverterParameter=(no value)}"
                         />
                       </DataTemplate>

--- a/PolicyPlusPlus/MainWindow/Commands.cs
+++ b/PolicyPlusPlus/MainWindow/Commands.cs
@@ -17,6 +17,14 @@ namespace PolicyPlusPlus
 {
     public sealed partial class MainWindow
     {
+        private static readonly DependencyProperty TrimmedToolTipCallbackTokenProperty =
+            DependencyProperty.RegisterAttached(
+                "TrimmedToolTipCallbackToken",
+                typeof(long),
+                typeof(MainWindow),
+                new PropertyMetadata(0L)
+            );
+
         private void SaveAccelerator_Invoked(
             KeyboardAccelerator sender,
             KeyboardAcceleratorInvokedEventArgs args
@@ -570,6 +578,50 @@ namespace PolicyPlusPlus
             try
             {
                 UpdateDetailsFromSelection();
+            }
+            catch { }
+        }
+
+        private void CellTextBlock_Loaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (sender is TextBlock tb)
+                {
+                    AttachTrimmedToolTipHandlers(tb);
+                    UpdateTrimmedToolTip(tb);
+                }
+            }
+            catch { }
+        }
+
+        private void AttachTrimmedToolTipHandlers(TextBlock tb)
+        {
+            long token = (long)tb.GetValue(TrimmedToolTipCallbackTokenProperty);
+            if (token == 0)
+            {
+                token = tb.RegisterPropertyChangedCallback(
+                    TextBlock.IsTextTrimmedProperty,
+                    CellTextBlock_IsTextTrimmedChanged
+                );
+                tb.SetValue(TrimmedToolTipCallbackTokenProperty, token);
+            }
+        }
+
+        private static void CellTextBlock_IsTextTrimmedChanged(
+            DependencyObject sender,
+            DependencyProperty dp
+        )
+        {
+            if (sender is TextBlock tb)
+                UpdateTrimmedToolTip(tb);
+        }
+
+        private static void UpdateTrimmedToolTip(TextBlock tb)
+        {
+            try
+            {
+                ToolTipService.SetToolTip(tb, tb.IsTextTrimmed ? tb.Text : null);
             }
             catch { }
         }


### PR DESCRIPTION
This pull request improves the display and usability of text cells in the main window by ensuring that trimmed (ellipsized) text in `TextBlock` elements shows a tooltip with the full text when truncated. The changes enhance user experience, especially when column contents are too long to fit in their cells.

**UI improvements for text cells:**

* Added `VerticalAlignment`, `TextTrimming="CharacterEllipsis"`, `TextWrapping="NoWrap"`, consistent `Margin`, and a `Loaded="CellTextBlock_Loaded"` event handler to all relevant `TextBlock` elements in `MainWindow.xaml` to ensure consistent appearance and enable dynamic tooltip support. [[1]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR867-R871) [[2]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR900-R904) [[3]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR927-R931) [[4]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR958-R962) [[5]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR990-R994) [[6]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR1022-R1026) [[7]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR1053-R1057) [[8]](diffhunk://#diff-ce78c54388125fe39e78bde18c72dc3727b06abf1b99c9033ce526d7930abaecR1084-R1088)

**Tooltip logic for trimmed text:**

* Introduced a new attached dependency property `TrimmedToolTipCallbackTokenProperty` in `MainWindow/Commands.cs` to manage property change callbacks for text trimming.
* Added the `CellTextBlock_Loaded` event handler and supporting methods (`AttachTrimmedToolTipHandlers`, `CellTextBlock_IsTextTrimmedChanged`, and `UpdateTrimmedToolTip`) to automatically show a tooltip with the full text only when the text is trimmed in a `TextBlock`.